### PR TITLE
Add set values function

### DIFF
--- a/Slider.js
+++ b/Slider.js
@@ -87,6 +87,23 @@ var Slider = React.createClass({
 
   },
 
+  set(values) {
+    this.optionsArray = this.props.optionsArray || converter.createArray(this.props.min,this.props.max,this.props.step);
+    this.stepLength = this.props.sliderLength/this.optionsArray.length;
+
+    var initialValues = values.map(value => converter.valueToPosition(value,this.optionsArray,this.props.sliderLength));
+
+    this.setState({
+      pressedOne: true,
+      valueOne: values[0],
+      valueTwo: values[1],
+      pastOne: initialValues[0],
+      pastTwo: initialValues[1],
+      positionOne: initialValues[0],
+      positionTwo: initialValues[1]
+    });
+  },
+
   startOne () {
     this.props.onValuesChangeStart();
     this.setState({


### PR DESCRIPTION

![multi-slider-reset](https://cloud.githubusercontent.com/assets/7199499/10555892/6e5eeb5c-742b-11e5-981d-525294037886.gif)
I added a set values function

use case: to manually set the values (without dragging), the position of the markers will follow

usage: 

```
var Slider = require('react-native-multi-slider');
var min = 0;
var max = 1000;
var SliderExample = React.createClass({
    getInitialState: function() {
      return {
        priceRange: [min, max]
      };
    },
    setPriceRange: function(priceRange){
      this.setState({
        priceRange: priceRange
      })
    },
    resetFilter: function() {
      this.refs.Slider.set([min,max])
    },

  render: function() {
    return (
       <Slider
        ref={'Slider'}
        values={[this.state.priceRange[0] || 0,this.state.priceRange[1] || 1000]}
        min={min}
        max={max}
        onValuesChange={this.setPriceRange}
        markerStyle={{height:30, width: 20, backgroundColor:'#E8E8E8', borderWidth: 0.5, borderColor: 'grey'}}
        selectedStyle={{backgroundColor: '#34C9A4'}}
        unselectedStyle={{backgroundColor: '#BBBBBB'}}>
      </Slider>
    )
  }
});
```

I needed this to reset my sliders by setting the values to min and max.
I have not run the above code, but I think the idea is clear.