### PR TITLE
Update values

### DIFF
--- a/Slider.js
+++ b/Slider.js
@@ -87,6 +87,16 @@ var Slider = React.createClass({
 
   },
 
+  componentWillReceiveProps(nextProps) {
+    var { values } = this.props;
+
+    // Maybe there is a more fancy way to check array
+    // inequality, but for now it works :).
+    if (nextProps.values.join() !== values.join()) {
+      this.set(nextProps.values);
+    }
+  },
+
   set(values) {
     this.optionsArray = this.props.optionsArray || converter.createArray(this.props.min,this.props.max,this.props.step);
     this.stepLength = this.props.sliderLength/this.optionsArray.length;

--- a/package.json
+++ b/package.json
@@ -26,8 +26,5 @@
   "bugs": {
     "url": "https://github.com/JackDanielsAndCode/react-native-multi-slider/issues"
   },
-  "homepage": "https://github.com/JackDanielsAndCode/react-native-multi-slider#readme",
-  "dependencies": {
-    "react-native": ">=0.14.2"
-  }
+  "homepage": "https://github.com/JackDanielsAndCode/react-native-multi-slider#readme"
 }


### PR DESCRIPTION
I think this is a more declarative way to update the marker positions by updating the `values` prop. Instead of calling `set(values)` through `refs` to change the slider values programmatically.  

I removed the RN dependency, because a RN project with a different RN version will cause naming collisions. And RN is available in a RN project anyways.

@jrans Would it be an option to switch to the RN Animated API to update the marker position during update or drag? This would enable more smooth animations.