### PR TITLE
Use nextProps for min, max, and step

### DIFF
--- a/Slider.js
+++ b/Slider.js
@@ -93,12 +93,12 @@ var Slider = React.createClass({
     // Maybe there is a more fancy way to check array
     // inequality, but for now it works :).
     if (nextProps.values.join() !== values.join()) {
-      this.set(nextProps.values);
+      this.set(nextProps.values, nextProps.min, nextProps.max, nextProps.step);
     }
   },
 
-  set(values) {
-    this.optionsArray = this.props.optionsArray || converter.createArray(this.props.min,this.props.max,this.props.step);
+  set(values, min, max, step) {
+    this.optionsArray = this.props.optionsArray || converter.createArray(min, max, step);
     this.stepLength = this.props.sliderLength/this.optionsArray.length;
 
     var initialValues = values.map(value => converter.valueToPosition(value,this.optionsArray,this.props.sliderLength));


### PR DESCRIPTION
The min, max, and step can also change in props causing the
multi-slider to malfunction when values are introduced that exceed or
are smaller than the old min-max.
A similar problem occurs new values that don’t fit into the old steps
change